### PR TITLE
Improve expectations failure error message

### DIFF
--- a/lib/http_ex/backend/mock.ex
+++ b/lib/http_ex/backend/mock.ex
@@ -276,12 +276,10 @@ defmodule HTTPEx.Backend.Mock do
           #{Request.summary(request)}
           """
 
-      {:error, :max_calls_reached, %{max_calls: 0} = expectation} ->
+      {:error, :max_calls_reached, %{max_calls: 0}} ->
         raise AssertionError,
           message: """
           An unexpected HTTP request was made
-
-          #{Expectation.summary(expectation)}
 
           #{Request.summary(request)}
           """
@@ -292,20 +290,18 @@ defmodule HTTPEx.Backend.Mock do
           Maximum number of HTTP calls already made for request
 
           #{Expectation.summary(expectation)}
-
-          #{Request.summary(request)}
           """
 
-      {:error, :expectations_not_met, missed, expectation} ->
+      {:error, :expectations_not_met, [{field, left, right} | _tail], _expectation} ->
+        # to keep things a bit more clear for the developer
+        # we only fail on the first expectation we found
         raise AssertionError,
+          left: left,
+          right: right,
           message: """
-          The HTTP request that was made, didn't match one or more expectations.
+          The HTTP request that was made, didn't match an expectation
 
-          #{Shared.attr("Fields mismatched")} #{Shared.value(missed)}
-
-          #{Expectation.summary(expectation)}
-
-          #{Request.summary(request)}
+          #{Shared.attr("Field mismatch")} #{Shared.value(field)}
           """
 
       {:error, error} ->

--- a/test/http_ex/backend/mock_test.exs
+++ b/test/http_ex/backend/mock_test.exs
@@ -140,7 +140,7 @@ defmodule HTTPEx.Backend.MockTest do
       )
 
       assert_raise AssertionError,
-                   ~r/The HTTP request that was made, didn't match one or more expectations/,
+                   ~r/The HTTP request that was made, didn't match an expectation/,
                    fn ->
                      Mock.request(%Request{
                        url: "http://www.example.com",


### PR DESCRIPTION
## Improve expectations failure error message

WIP

Currently it's pretty hard to see what expectation failed on a request. For example:

```elixir
expect_request!(
  endpoint: "http://localhost:4000/test",
  expect_body: "The request body"
)
```

It's currently really hard to see what the value that was expected and what the value was that was actually used. Just like ExUnit, it would be nice to see a diff between the left and right value.

* [ ] Review required
* [ ] Includes 1+ tests
* [ ] Fully tested locally

