### PR TITLE
Adds stacktrace to expectations, making them easier to spot

### DIFF
--- a/lib/http_ex/backend/mock.ex
+++ b/lib/http_ex/backend/mock.ex
@@ -202,11 +202,12 @@ defmodule HTTPEx.Backend.Mock do
       ...>   endpoint: "http://www.example.com",
       ...>   response: %{status: 200, body: "OK!", headers: [{"Content-Type", "application/json"}]},
       ...> )
-
   """
   @spec expect_request!(Keyword.t()) :: :ok | {:error, atom()}
   def expect_request!(opts) when is_list(opts) do
-    expectation = Expectation.new!(Keyword.put(opts, :type, :assert))
+    expectation =
+      Expectation.new!(Keyword.merge(opts, type: :assert, stacktrace: expectation_stacktrace()))
+
     add!(@local_server, expectation)
   end
 
@@ -224,7 +225,7 @@ defmodule HTTPEx.Backend.Mock do
   def assert_no_request!(opts) when is_list(opts) do
     expectation =
       opts
-      |> Keyword.put(:type, :reject)
+      |> Keyword.merge(type: :reject, stacktrace: expectation_stacktrace())
       |> Expectation.new!()
 
     add!(@local_server, expectation)
@@ -247,7 +248,9 @@ defmodule HTTPEx.Backend.Mock do
   See `expect_request!/1`
   """
   def stub_request!(opts) when is_list(opts) do
-    expectation = Expectation.new!(Keyword.put(opts, :type, :stub))
+    expectation =
+      Expectation.new!(Keyword.merge(opts, type: :stub, stacktrace: expectation_stacktrace()))
+
     server = if Keyword.get(opts, :global), do: @global_server, else: @local_server
     add!(server, expectation)
   end
@@ -274,6 +277,11 @@ defmodule HTTPEx.Backend.Mock do
           No HTTP request found that are registered with `expect_request`
 
           #{Request.summary(request)}
+
+          Registered expectations:
+
+          #{registered_expectations_summary(@local_server, local_owner_pid)}
+          #{registered_expectations_summary(@global_server, global_owner_pid)}
           """
 
       {:error, :max_calls_reached, %{max_calls: 0}} ->
@@ -437,4 +445,21 @@ defmodule HTTPEx.Backend.Mock do
     do: %{request | body: to_string(body)}
 
   defp parse_body(%Request{} = request), do: request
+
+  defp expectation_stacktrace do
+    {_, stacktrace} = Process.info(self(), :current_stacktrace)
+
+    Enum.at(stacktrace, 3)
+  end
+
+  defp registered_expectations_summary(server, owner_pid) do
+    server
+    |> list(owner_pid)
+    |> Enum.filter(fn expectation ->
+      expectation.max_calls == :infinity || expectation.calls < expectation.max_calls
+    end)
+    |> Enum.map_join("\n", fn expectation ->
+      "* #{Exception.format_stacktrace_entry(expectation.stacktrace)}"
+    end)
+  end
 end

--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -40,6 +40,7 @@ defmodule HTTPEx.Backend.Mock.Expectation do
             min_calls: 1,
             priority: 0,
             response: %{status: 200, body: "OK"},
+            stacktrace: nil,
             type: :assertion
 
   @type string_formats() :: :json | :xml | :form
@@ -132,6 +133,7 @@ defmodule HTTPEx.Backend.Mock.Expectation do
           min_calls: non_neg_integer(),
           priority: non_neg_integer(),
           response: response_func() | response_map() | response_error(),
+          stacktrace: nil | tuple(),
           type: :assertion | :stub
         }
 
@@ -171,6 +173,7 @@ defmodule HTTPEx.Backend.Mock.Expectation do
   - expect_path
   - expect_query
   - calls
+  - stacktrace
 
   ## Examples
 
@@ -259,6 +262,7 @@ defmodule HTTPEx.Backend.Mock.Expectation do
       min_calls: min_calls,
       max_calls: max_calls,
       response: response,
+      stacktrace: Keyword.get(opts, :stacktrace),
       type: expectation_type
     }
     |> set_expect!(:body, expect_body)
@@ -279,6 +283,8 @@ defmodule HTTPEx.Backend.Mock.Expectation do
   def summary(%Expectation{} = expectation) do
     """
       #{Shared.header("HTTP expectation ##{expectation.index}")}
+
+      #{Exception.format_stacktrace_entry(expectation.stacktrace)}
 
       #{Shared.attr("Description")} #{Shared.value(expectation.description)}
 


### PR DESCRIPTION
## Adds stacktrace to expectations, making them easier to spot

When working with HTTPEx expectations and running into unmatched requests, it's hard to spot which expectations are defined where and what is not matching.

This small PR should fix this. When a request is made that is not matched, the summary should show where the expectation itself was initially defined.

* [ ] Review required
* [ ] Includes 1+ tests
* [ ] Fully tested locally

