### PR TITLE
Let logging handle pdf responses

### DIFF
--- a/lib/http_ex/response.ex
+++ b/lib/http_ex/response.ex
@@ -32,7 +32,7 @@ defmodule HTTPEx.Response do
 
     #{Shared.attr("Body")}
 
-    #{Shared.value(response.body)}
+    #{Shared.value(safe_to_string(response.body))}
     """
   end
 
@@ -59,5 +59,15 @@ defmodule HTTPEx.Response do
       {"http.status_code", response.status},
       {"http.retries", response.retries}
     ])
+  end
+
+  # In case of PDF's that are retrieved, we may have to parse them to binary
+  # before interpolating them.
+  defp safe_to_string(string) do
+    String.to_charlist(string)
+
+    string
+  rescue
+    UnicodeConversionError -> :unicode.characters_to_binary(string, :latin1)
   end
 end

--- a/lib/http_ex/response.ex
+++ b/lib/http_ex/response.ex
@@ -64,9 +64,7 @@ defmodule HTTPEx.Response do
   # In case of PDF's that are retrieved, we may have to parse them to binary
   # before interpolating them.
   defp safe_to_string(string) do
-    String.to_charlist(string)
-
-    string
+    string |> String.to_charlist() |> to_string()
   rescue
     UnicodeConversionError -> :unicode.characters_to_binary(string, :latin1)
   end

--- a/test/http_ex_test.exs
+++ b/test/http_ex_test.exs
@@ -7,6 +7,9 @@ defmodule HTTPExTest do
   alias HTTPEx.Response
   alias HTTPExTest.MockBackend
 
+  import ExUnit.CaptureLog
+  require Logger
+
   doctest HTTPEx
 
   defmodule MockBackend do
@@ -101,6 +104,16 @@ defmodule HTTPExTest do
   end
 
   describe "get/2" do
+    setup do
+      log_fn = Application.get_env(:http_ex, :log)
+
+      on_exit(fn ->
+        Application.put_env(:http_ex, :log, log_fn)
+      end)
+
+      :ok
+    end
+
     test "OK" do
       assert HTTPEx.get("http://www.example.com", backend: MockBackend) ==
                {:ok,
@@ -115,7 +128,17 @@ defmodule HTTPExTest do
     end
 
     test "OK with pdf as response" do
-      assert HTTPEx.get("http://www.example.com/pdf.pdf", backend: MockBackend) ==
+      Application.put_env(:http_ex, :log, &Logger.info/1)
+
+      {result, log} =
+        with_log(fn ->
+          HTTPEx.get("http://www.example.com/pdf.pdf", backend: MockBackend)
+        end)
+
+      assert log =~
+               "\e[4mHTTP response:\e[24m\n\n\e[1mClient:\e[22m \e[3m:httpoison\e[23m\n\e[1mStatus:\e[22m \e[3m200\e[23m\n\e[1mRetries:\e[22m \e[3m1\e[23m\n\e[1mHeaders:\e[22m\n\n\e[3m[]\e[23m\n\n\e[1mBody:\e[22m\n\n\e[3m%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040\e[23m\n\n\e[0m"
+
+      assert result ==
                {:ok,
                 %HTTPEx.Response{
                   body: "%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040",

--- a/test/http_ex_test.exs
+++ b/test/http_ex_test.exs
@@ -136,7 +136,7 @@ defmodule HTTPExTest do
         end)
 
       assert log =~
-               ~s(\e[4mHTTP response:\e[24m\n\n\e[1mClient:\e[22m \e[3m:httpoison\e[23m\n\e[1mStatus:\e[22m \e[3m200\e[23m\n\e[1mRetries:\e[22m \e[3m1\e[23m\n\e[1mHeaders:\e[22m\n\n\e[3m[]\e[23m\n\n\e[1mBody:\e[22m\n\n\e[3m%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040\e[23m\n\n\e[0m)
+               ~s(\e[4mHTTP response:\e[24m\n\n\e[1mClient:\e[22m \e[3m:httpoison\e[23m\n\e[1mStatus:\e[22m \e[3m200\e[23m\n\e[1mRetries:\e[22m \e[3m1\e[23m\n\e[1mHeaders:\e[22m\n\n\e[3m[]\e[23m\n\n\e[1mBody:\e[22m\n\n\e[3m%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040\e)
 
       assert result ==
                {:ok,

--- a/test/http_ex_test.exs
+++ b/test/http_ex_test.exs
@@ -21,6 +21,16 @@ defmodule HTTPExTest do
       {:ok, %HTTPoison.Response{status_code: 200, body: "OK!"}}
     end
 
+    def request(%Request{method: :get, url: "http://www.example.com/pdf.pdf"} = request) do
+      assert request.headers == []
+
+      {:ok,
+       %HTTPoison.Response{
+         status_code: 200,
+         body: "%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040"
+       }}
+    end
+
     def request(%Request{method: :get, url: "http://www.example.com/redirect"} = request) do
       assert request.headers == []
       {:ok, %HTTPoison.Response{status_code: 302, body: "You are being redirected"}}
@@ -96,6 +106,19 @@ defmodule HTTPExTest do
                {:ok,
                 %HTTPEx.Response{
                   body: "OK!",
+                  client: :httpoison,
+                  retries: 1,
+                  status: 200,
+                  parsed_body: nil,
+                  headers: []
+                }}
+    end
+
+    test "OK with pdf as response" do
+      assert HTTPEx.get("http://www.example.com/pdf.pdf", backend: MockBackend) ==
+               {:ok,
+                %HTTPEx.Response{
+                  body: "%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040",
                   client: :httpoison,
                   retries: 1,
                   status: 200,

--- a/test/http_ex_test.exs
+++ b/test/http_ex_test.exs
@@ -136,7 +136,7 @@ defmodule HTTPExTest do
         end)
 
       assert log =~
-               "\e[4mHTTP response:\e[24m\n\n\e[1mClient:\e[22m \e[3m:httpoison\e[23m\n\e[1mStatus:\e[22m \e[3m200\e[23m\n\e[1mRetries:\e[22m \e[3m1\e[23m\n\e[1mHeaders:\e[22m\n\n\e[3m[]\e[23m\n\n\e[1mBody:\e[22m\n\n\e[3m%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040\e[23m\n\n\e[0m"
+               ~s(\e[4mHTTP response:\e[24m\n\n\e[1mClient:\e[22m \e[3m:httpoison\e[23m\n\e[1mStatus:\e[22m \e[3m200\e[23m\n\e[1mRetries:\e[22m \e[3m1\e[23m\n\e[1mHeaders:\e[22m\n\n\e[3m[]\e[23m\n\n\e[1mBody:\e[22m\n\n\e[3m%PDF-1.4\n%ÓôÌá\n1 0 obj\n<<\n/CreationDate(D:2025040\e[23m\n\n\e[0m)
 
       assert result ==
                {:ok,


### PR DESCRIPTION
Because:
When fetching PDF's with HTTPEx I encountered the following error:

```
[error] ** (ArgumentError) argument error
    (stdlib 6.2) io.erl:203: :io.put_chars(:standard_io, [<<27, 91, 52, 109, 72, 84, 84, 80, 32, 114, 101, 115, 112, 111, 110, 115, 101, 58, 27, 91, 50, 52, 109, 10, 10, 27, 91, 49, 109, 67, 108, 105, 101, 110, 116, 58, 27, 91, 50, 50, 109, 32, 27, 91, 51, 109, 58, 102, 105, ...>>, 10])
    (http_ex 0.1.0) lib/http_ex/logging.ex:43: HTTPEx.Logging.log/1
    (http_ex 0.1.0) lib/http_ex/logging.ex:50: HTTPEx.Logging.log/1
```

I was able to follow this back to the summary of the response, with Michaël we looked at knowing upfront we had to do this but couldn't find it. If there's a better way to know how to make a string out of it, idea's are welcome.

We've now implemented a rescue for this call which uses the original response or else tries to encode this.

* [x] Review required
* [x] Includes 1+ tests
* [x] Fully tested locally

