### PR TITLE
Use the orignal values in the assertion error

### DIFF
--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -1046,18 +1046,21 @@ defmodule HTTPEx.Backend.Mock.Expectation do
 
   defp match_value(:string_with_format, {matcher, :json}, value_to_match)
        when is_binary(matcher) and is_binary(value_to_match) do
-    match_left_right(
-      JSON.normalize(matcher),
-      JSON.normalize(value_to_match)
-    )
+    with {false, _, _} <-
+           match_left_right(JSON.normalize(matcher), JSON.normalize(value_to_match)) do
+      {false, matcher, value_to_match}
+    end
   end
 
   defp match_value(:string_with_format, {matcher, :xml}, value_to_match)
        when is_binary(matcher) and is_binary(value_to_match) do
-    match_left_right(
-      XML.normalize(matcher),
-      XML.normalize(value_to_match)
-    )
+    with {false, _, _} <-
+           match_left_right(
+             XML.normalize(matcher),
+             XML.normalize(value_to_match)
+           ) do
+      {false, matcher, value_to_match}
+    end
   end
 
   defp match_value(:string_with_format, {matcher, :form}, value_to_match)


### PR DESCRIPTION
Because:
- It makes it easier to deal with the values, copy paste it and ensure you got the input you need for the test.
- Easier to recognize where the value came from. When you get an Elixir Map returned while you expect it to be json is confusing.

This commit:
- Returns the original value after matching left and right. So that you see the difference on what is expected to go in, rather than what it internally matches on.


Example:
```ex
      Mock.expect_request!(
        endpoint: "http://www.example.com",
        method: :post,
        expect_body: {JSON.encode!(%{"data" => false}), :json},
        response: %{status: 200, body: "OK"}
      )
```

| before | after |
| --- | --- |
| <img width="621" alt="Screenshot 2025-04-08 at 19 18 26" src="https://github.com/user-attachments/assets/11ad8e44-7313-4582-8abb-b6bdb561a1ad" /> | <img width="630" alt="Screenshot 2025-04-08 at 19 17 48" src="https://github.com/user-attachments/assets/a49524fc-d315-42a2-8149-fd015c673018" /> | 


* [x] Review required
* [ ] Includes 1+ tests
* [x] Fully tested locally

