### PR TITLE
Move export logging to the log/1 function

### DIFF
--- a/lib/http_ex/logging.ex
+++ b/lib/http_ex/logging.ex
@@ -18,10 +18,6 @@ defmodule HTTPEx.Logging do
       |> Tracing.set_attributes()
     end
 
-    if export_logging?() do
-      export_log_fn().(entity)
-    end
-
     entity
   end
 
@@ -44,6 +40,10 @@ defmodule HTTPEx.Logging do
   def log(%module{} = entity) do
     if logging?() do
       log_fn().(module.summary(entity))
+    end
+
+    if export_logging?() do
+      export_log_fn().(entity)
     end
 
     entity

--- a/test/http_ex/logging_test.exs
+++ b/test/http_ex/logging_test.exs
@@ -30,31 +30,6 @@ defmodule HTTPEx.LoggingTest do
                  retries: 1,
                  parsed_body: nil
                },
-               %HTTPEx.Response{
-                 status: 200,
-                 body: "OK!",
-                 client: :httpoison,
-                 headers: [],
-                 retries: 1,
-                 parsed_body: nil
-               },
-               %HTTPEx.Request{
-                 options: [
-                   pool: HTTPEx.FinchTestPool,
-                   retry_status_codes: [500, 502, 503, 504],
-                   retry_error_codes: [:closed, :timeout],
-                   transport_max_retries: 3,
-                   transport_retry_timeout: 2000,
-                   allow_redirects: true,
-                   backend: HTTPExTest.MockBackend
-                 ],
-                 body: "",
-                 url: "http://www.example.com",
-                 client: :httpoison,
-                 headers: [],
-                 method: :get,
-                 retries: 1
-               },
                %HTTPEx.Request{
                  options: [
                    pool: HTTPEx.FinchTestPool,


### PR DESCRIPTION
Because:
The trace/1 function is used more than once, but that causes issues for export_logging/1
The function is made for logging and is more closely aligned with what we're trying to solve with export_logging. The reason it was in trace/1 in the first place was because i thought i needed the information set there, but that wasn't the case after all.


* [ ] Review required
* [x] Includes 1+ tests
* [x] Fully tested locally

