### PR TITLE
Show the diff with normalized JSON

### DIFF
--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -1043,8 +1043,10 @@ defmodule HTTPEx.Backend.Mock.Expectation do
 
   defp match_value(:string_with_format, {matcher, :json}, value_to_match)
        when is_binary(matcher) and is_binary(value_to_match) do
-    with {false, _, _} <-
-           match_left_right(JSON.normalize(matcher), JSON.normalize(value_to_match)) do
+    matcher = JSON.normalize(matcher)
+    value_to_match = JSON.normalize(value_to_match)
+
+    with {false, _, _} <- match_left_right(matcher, value_to_match) do
       {false, matcher, value_to_match}
     end
   end


### PR DESCRIPTION
The diff that was shown would use the text JSON from both sides as a comparison. This could be hard to parse especially when the order of the two sides are different. 
By decoding both sides from json to maps, the diffing can highlight better what needs to change.