### PR TITLE
Validate the options for expect_request!

### DIFF
--- a/lib/http_ex/backend/mock.ex
+++ b/lib/http_ex/backend/mock.ex
@@ -109,6 +109,27 @@ defmodule HTTPEx.Backend.Mock do
     end
   end
 
+  @allwed_expect_request_options [
+    :body,
+    :body_format,
+    :description,
+    :expect_body,
+    :expect_body_format,
+    :expect_headers,
+    :expect_path,
+    :expect_query,
+    :headers,
+    :host,
+    :endpoint,
+    :min_calls,
+    :max_calls,
+    :method,
+    :path,
+    :port,
+    :query,
+    :response
+  ]
+
   @doc """
   Adds an asserted request. It will require a match always on `endpoint`, `method` and (optional) `caller`.
   If you try to add an expected request that already exists, this function will throw an exception.
@@ -205,6 +226,8 @@ defmodule HTTPEx.Backend.Mock do
   """
   @spec expect_request!(Keyword.t()) :: :ok | {:error, atom()}
   def expect_request!(opts) when is_list(opts) do
+    validate_options(opts)
+
     expectation =
       opts
       |> Keyword.put(:type, :assert)
@@ -491,5 +514,16 @@ defmodule HTTPEx.Backend.Mock do
         Mismatches: #{Enum.map_join(mismatches, ", ", &to_string/1)}
       """
     end)
+  end
+
+  defp validate_options(options) do
+    option_keys = Keyword.keys(options)
+
+    if option_keys -- @allwed_expect_request_options != [] do
+      disallowed_options = option_keys -- @allwed_expect_request_options
+
+      raise ArgumentError,
+            "The option(s) '#{disallowed_options |> Enum.join(", ")}' are not allowed"
+    end
   end
 end


### PR DESCRIPTION
Because:
When you enter `expected_body: {some_json, :json},` and the tests succeed you might think you've tested the proper json is send. But because this option isn't used that's not the case. So to guard against that we're now checking if the option that's given will actually be used, rather then ignore it the test will now raise.


* [x] Review required
* [x] Fully tested locally

