### PR TITLE
bugix: support min_calls and max_calls in expect_request!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.3 (2025-07-22)
+
+### Bug Fixes
+
+- Fixed `max_calls` and `min_calls` options not being respected in `expect_request!`
+
 ## v0.2.2 (2025-04-30)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ by adding `http_ex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:http_ex, "~> 0.2.2"}
+    {:http_ex, "~> 0.2.3"}
   ]
 end
 ```

--- a/lib/http_ex/backend/mock.ex
+++ b/lib/http_ex/backend/mock.ex
@@ -112,6 +112,7 @@ defmodule HTTPEx.Backend.Mock do
   @allwed_expect_request_options [
     :body,
     :body_format,
+    :calls,
     :description,
     :expect_body,
     :expect_body_format,

--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -186,7 +186,10 @@ defmodule HTTPEx.Backend.Mock.Expectation do
       case type do
         :stub -> {0, :infinity}
         :reject -> {0, 0}
-        :assert -> {1, Keyword.get(opts, :calls, 1)}
+        :assert ->
+          min = Keyword.get(opts, :min_calls, 1)
+          max = Keyword.get(opts, :max_calls, Keyword.get(opts, :calls, 1))
+          {min, max}
       end
 
     expectation_type =

--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -193,18 +193,7 @@ defmodule HTTPEx.Backend.Mock.Expectation do
 
         :assert ->
           min = Keyword.get(opts, :min_calls, 1)
-
-          max =
-            cond do
-              Keyword.has_key?(opts, :max_calls) ->
-                Keyword.get(opts, :max_calls)
-
-              Keyword.has_key?(opts, :min_calls) ->
-                :infinity
-
-              true ->
-                1
-            end
+          max = Keyword.get(opts, :max_calls) || Keyword.get(opts, :calls, min)
 
           {min, max}
       end

--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -169,7 +169,8 @@ defmodule HTTPEx.Backend.Mock.Expectation do
   - expect_headers
   - expect_path
   - expect_query
-  - calls
+  - min_calls
+  - max_calls
   - stacktrace
 
   ## Examples
@@ -184,11 +185,27 @@ defmodule HTTPEx.Backend.Mock.Expectation do
 
     {min_calls, max_calls} =
       case type do
-        :stub -> {0, :infinity}
-        :reject -> {0, 0}
+        :stub ->
+          {0, :infinity}
+
+        :reject ->
+          {0, 0}
+
         :assert ->
           min = Keyword.get(opts, :min_calls, 1)
-          max = Keyword.get(opts, :max_calls, Keyword.get(opts, :calls, 1))
+
+          max =
+            cond do
+              Keyword.has_key?(opts, :max_calls) ->
+                Keyword.get(opts, :max_calls)
+
+              Keyword.has_key?(opts, :min_calls) ->
+                :infinity
+
+              true ->
+                1
+            end
+
           {min, max}
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule HttpEx.MixProject do
       source_url: "https://github.com/wuunder/http_ex",
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
-      version: "0.2.2"
+      version: "0.2.3"
     ]
   end
 

--- a/test/http_ex/backend/mock_test.exs
+++ b/test/http_ex/backend/mock_test.exs
@@ -206,7 +206,7 @@ defmodule HTTPEx.Backend.MockTest do
                    end
     end
 
-    test "min_calls met" do
+    test "does not raise an error when minimum amount of calls is reached" do
       Mock.expect_request!(
         endpoint: "http://www.example.com",
         min_calls: 2,
@@ -251,21 +251,13 @@ defmodule HTTPEx.Backend.MockTest do
         response: %{status: 200, body: "OK"}
       )
 
-      Enum.each(1..2, fn _ ->
+      Enum.each(1..3, fn _ ->
         Mock.request(%Request{
           client: :httpoison,
           url: "http://www.example.com",
           method: :get
         })
       end)
-
-      Mock.verify!(self())
-
-      Mock.request(%Request{
-        client: :httpoison,
-        url: "http://www.example.com",
-        method: :get
-      })
 
       assert_raise AssertionError,
                    ~r/Maximum number of HTTP calls already made for request/,

--- a/test/http_ex/backend/mock_test.exs
+++ b/test/http_ex/backend/mock_test.exs
@@ -224,7 +224,7 @@ defmodule HTTPEx.Backend.MockTest do
       Mock.verify!(self())
     end
 
-    test "min_calls with max_calls met" do
+    test "does not raise an error with the accepted amount of requests" do
       Mock.expect_request!(
         endpoint: "http://www.example.com",
         min_calls: 1,


### PR DESCRIPTION
This PR fixes `min_calls` and `max_calls` options for `expect_request!`. These options were documented but completely ignored by the code. Max was taken from `calls` option, min value was hardcoded to 1. 

The fix:

- If `max_calls` is explicitly provided: use it
- If only `min_calls` is provided: use `calls` (for backwards compatibility), if `calls` not provided either, set `max_calls` to `min_calls` value to avoid a clash
- Default case (neither specified): single call expectation



* [x] Review required
* [x] Includes 1+ tests
* [x] Fully tested locally

