### PR TITLE
Make sure to match only on chosen matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Bug Fixes
 
+- Fix expect_request! when multiple requests are made to the same URL with different bodys.
+    When a `:body` matcher is used, the matcher is now prefering that over Expectations that omitted this.
+
+## v0.2.5 (2025-08-15)
+
+### Bug Fixes
+
 - Fixed `http_client`  option not being allowed in `expect_request!`
 
 ## v0.2.4 (2025-08-15)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ by adding `http_ex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:http_ex, "~> 0.2.5"}
+    {:http_ex, "~> 0.2.6"}
   ]
 end
 ```

--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -836,7 +836,8 @@ defmodule HTTPEx.Backend.Mock.Expectation do
         fn {expectation, match_result} ->
           {true, fields, _misses, _vars} = match_result
 
-          match_score = length(fields)
+          match_score =
+            fields |> Enum.reject(&(expectation.matchers[&1] == :any)) |> length()
 
           expects_calls? = expectation.type == :assertion && expectation.min_calls >= 1
 

--- a/lib/http_ex/backend/mock/expectation.ex
+++ b/lib/http_ex/backend/mock/expectation.ex
@@ -770,10 +770,10 @@ defmodule HTTPEx.Backend.Mock.Expectation do
       ...>     }
       ...>   )
       ...>
-      ...> match == expectation_1
-      true
+      ...> match
+      expectation_2
       iex> vars
-      %{}
+      %{"api_version" => "v1"}
       iex> {:ok, match, vars} =
       ...>   Expectation.find_matching_expectation(
       ...>     expectations,
@@ -785,8 +785,8 @@ defmodule HTTPEx.Backend.Mock.Expectation do
       ...>     }
       ...>   )
       ...>
-      ...> match == expectation_1
-      true
+      ...> match
+      expectation_1
       iex> vars
       %{}
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule HttpEx.MixProject do
       source_url: "https://github.com/wuunder/http_ex",
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
-      version: "0.2.5"
+      version: "0.2.6"
     ]
   end
 

--- a/test/http_ex/backend/mock_test.exs
+++ b/test/http_ex/backend/mock_test.exs
@@ -88,6 +88,29 @@ defmodule HTTPEx.Backend.MockTest do
       end
     end
 
+    test "OK, using the same endpoint for multiple request but with different body's" do
+      Mock.expect_request!(
+        endpoint: "http://www.example.com/soap",
+        body: "can't find this one",
+        response: %{status: 200, body: "OK"}
+      )
+
+      Mock.expect_request!(
+        endpoint: "http://www.example.com/soap",
+        body: "find_this_one",
+        expect_body: "find_this_one",
+        response: %{status: 200, body: "OK"}
+      )
+
+      assert Mock.request(%Request{
+               client: :httpoison,
+               url: "http://www.example.com/soap",
+               method: :get,
+               body: "find_this_one"
+             }) ==
+               {:ok, %HTTPoison.Response{status_code: 200, body: "OK", headers: []}}
+    end
+
     test "max calls reached" do
       Mock.expect_request!(
         endpoint: "http://www.example.com",


### PR DESCRIPTION
Because:
When doing soap requests in tests we often find the same endpoint to be used for multiple calls. The only difference here would be the body that we send to that endpoint.

The body was already part of the matchers so adding it works, but for expect_request!'s where the body was omitted an :any was used and thus it would always match. This resulted into some tests that used this library not to find the right expectation for their request.

We've now changed the match_score so that any's will be excluded from the match score. So that a closer match with a more specific target will be used over others.


* [x] Review required
* [x] Includes 1+ tests
* [x] Fully tested locally

