### PR TITLE
Inspect value for response body

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.3-otp-27
-erlang 27.3.1
+elixir   1.19.5-otp-28
+erlang   28.4.1

--- a/lib/http_ex/response.ex
+++ b/lib/http_ex/response.ex
@@ -55,7 +55,7 @@ defmodule HTTPEx.Response do
     Shared.trace_attrs([
       {"error", error?},
       {"http.error", reason},
-      {"http.response_body", response.body},
+      {"http.response_body", Shared.inspect_value(response.body)},
       {"http.response_headers", inspect(response.headers)},
       {"http.status_code", response.status},
       {"http.retries", response.retries}


### PR DESCRIPTION
In some cases we don't get the response_body in honeycomb, this might be because the value isn't properly formatted. In any case adding this shouldn't cause issues even if it doesn't help, so we might as well check if this improves behaviour.
